### PR TITLE
Login Register 継続/総計 機能追加

### DIFF
--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Providers\RouteServiceProvider;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
 
 class LoginController extends Controller
 {
@@ -36,5 +37,37 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
+    }
+
+    public function login(Request $request)
+    {
+        $this->validateLogin($request);
+
+
+        // If the class is using the ThrottlesLogins trait, we can automatically throttle
+        // the login attempts for this application. We'll key this by the username and
+        // the IP address of the client making these requests into this application.
+        if (method_exists($this, 'hasTooManyLoginAttempts') &&
+            $this->hasTooManyLoginAttempts($request)) {
+            $this->fireLockoutEvent($request);
+
+            return $this->sendLockoutResponse($request);
+        }
+
+        if ($this->attemptLogin($request)) {
+
+            if ($request->hasSession()) {
+                $request->session()->put('auth.password_confirmed_at', time());
+            }
+
+            return $this->sendLoginResponse($request);
+        }
+
+        // If the login attempt was unsuccessful we will increment the number of attempts
+        // to login and redirect the user back to the login form. Of course, when this
+        // user surpasses their maximum number of attempts they will get locked out.
+        $this->incrementLoginAttempts($request);
+
+        return $this->sendFailedLoginResponse($request);
     }
 }

--- a/src/app/Http/Controllers/Auth/LoginController.php
+++ b/src/app/Http/Controllers/Auth/LoginController.php
@@ -88,7 +88,7 @@ class LoginController extends Controller
         $yestaday = Carbon::yesterday()->format('Y-m-d');
 
         $toContinuation = ($login->login_date < $yestaday) ? $this->resetTotalContinuation : $user->total_continuation++;
-        $toCumulative = ($login->login_date <= $yestaday) ?? $user->total_continuation++;
+        $toCumulative = ($login->login_date <= $yestaday) ? $user->total_cumulative : $user->total_cumulative++;
 
         DB::table('logins')->where('user_id', $login->user_id)->update(['login_date' => now()->format('Y-m-d')]);
         User::where('id', $login->user_id)->update(['total_continuation' => $toContinuation, 'total_cumulative' => $toCumulative]);

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -3,9 +3,13 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Providers\RouteServiceProvider;
+use App\Models\Login;
 use App\Models\User;
+use App\Providers\RouteServiceProvider;
+use Illuminate\Auth\Events\Registered;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 
@@ -69,5 +73,33 @@ class RegisterController extends Controller
             'email' => $data['email'],
             'password' => Hash::make($data['password']),
         ]);
+    }
+
+    /**
+     * Handle a registration request for the application.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\RedirectResponse|\Illuminate\Http\JsonResponse
+     */
+    public function register(Request $request)
+    {
+        $this->validator($request->all())->validate();
+
+        event(new Registered($user = $this->create($request->all())));
+
+        Login::insert([
+            'user_id' => $user->id,
+            'login_date' => now(),
+        ]);
+
+        $this->guard()->login($user);
+
+        if ($response = $this->registered($request, $user)) {
+            return $response;
+        }
+
+        return $request->wantsJson()
+                    ? new JsonResponse([], 201)
+                    : redirect($this->redirectPath());
     }
 }

--- a/src/app/Http/Controllers/Auth/RegisterController.php
+++ b/src/app/Http/Controllers/Auth/RegisterController.php
@@ -36,6 +36,11 @@ class RegisterController extends Controller
     protected $redirectTo = RouteServiceProvider::HOME;
 
     /**
+     * Defualt Total continuation
+     */
+    protected $DafultNumber = 1;
+
+    /**
      * Create a new controller instance.
      *
      * @return void
@@ -69,9 +74,11 @@ class RegisterController extends Controller
     protected function create(array $data)
     {
         return User::create([
-            'name' => $data['name'],
-            'email' => $data['email'],
-            'password' => Hash::make($data['password']),
+            'name'               => $data['name'],
+            'email'              => $data['email'],
+            'password'           => Hash::make($data['password']),
+            'total_cumulative'   => $this->DafultNumber,
+            'total_continuation' => $this->DafultNumber,
         ]);
     }
 

--- a/src/app/Http/Controllers/ReportController.php
+++ b/src/app/Http/Controllers/ReportController.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Report;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 
 class ReportController extends Controller
 {
@@ -17,6 +18,8 @@ class ReportController extends Controller
      */
     public function reportIndex()
     {
-        return view('report');
+        $loginUser = User::find(Auth::id())->first();
+        $userList = User::get();
+        return view('report', compact('userList', 'loginUser'));
     }
 }

--- a/src/app/Http/Controllers/ReportController.php
+++ b/src/app/Http/Controllers/ReportController.php
@@ -18,7 +18,7 @@ class ReportController extends Controller
      */
     public function reportIndex()
     {
-        $loginUser = User::find(Auth::id())->first();
+        $loginUser = User::find(Auth::id());
         $userList = User::get();
         return view('report', compact('userList', 'loginUser'));
     }

--- a/src/app/Models/Login.php
+++ b/src/app/Models/Login.php
@@ -9,5 +9,8 @@ class Login extends Model
 {
     use HasFactory;
 
+    const CREATED_AT = NULL;
+    const UPDATED_AT = NULL;
+
     protected $fillable = ['user_id', 'login_date'];
 }

--- a/src/app/Models/Login.php
+++ b/src/app/Models/Login.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Login extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['user_id', 'login_date'];
+}

--- a/src/app/Models/User.php
+++ b/src/app/Models/User.php
@@ -32,6 +32,8 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'created_at',
+        'updated_at',
     ];
 
     /**

--- a/src/database/factories/LoginFactory.php
+++ b/src/database/factories/LoginFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\Models\User;
+
+class LoginFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'user_id' => User::factory()->create()->id,
+            'login_date' => now()->format('Y-m-d'),
+        ];
+    }
+}

--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -3,7 +3,6 @@
 namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
-use Illuminate\Support\Str;
 use Illuminate\Support\Facades\Hash;
 
 class UserFactory extends Factory
@@ -20,7 +19,7 @@ class UserFactory extends Factory
             'name' => $faker->name(),
             'email' => $faker->unique()->safeEmail(),
             'password' => Hash::make('tt2123244'),
-            'comment'   => Str::random(10),
+            'comment'   => $faker->realText(20),
             'total_continuation' => $faker->unique()->numberBetween(10,50),
             'total_cumulative' => $faker->unique()->numberBetween(100,200),
         ];

--- a/src/database/factories/UserFactory.php
+++ b/src/database/factories/UserFactory.php
@@ -4,6 +4,7 @@ namespace Database\Factories;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
+use Illuminate\Support\Facades\Hash;
 
 class UserFactory extends Factory
 {
@@ -14,12 +15,14 @@ class UserFactory extends Factory
      */
     public function definition()
     {
+        $faker = \Faker\Factory::create("ja_JP");
         return [
-            'name' => $this->faker->name(),
-            'email' => $this->faker->unique()->safeEmail(),
-            'email_verified_at' => now(),
-            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-            'remember_token' => Str::random(10),
+            'name' => $faker->name(),
+            'email' => $faker->unique()->safeEmail(),
+            'password' => Hash::make('tt2123244'),
+            'comment'   => Str::random(10),
+            'total_continuation' => $faker->unique()->numberBetween(10,50),
+            'total_cumulative' => $faker->unique()->numberBetween(100,200),
         ];
     }
 

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,6 +20,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->string('comment')->nullable();
             $table->string('file_name')->default('fuji.png');
+            $table->integer('total_cumulative')->default(1);
             $table->integer('total_continuation')->default(1);
             $table->rememberToken();
             $table->timestamps();

--- a/src/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/src/database/migrations/2014_10_12_000000_create_users_table.php
@@ -20,7 +20,7 @@ class CreateUsersTable extends Migration
             $table->string('password');
             $table->string('comment')->nullable();
             $table->string('file_name')->default('fuji.png');
-            $table->integer('total_continuation')->nullable();
+            $table->integer('total_continuation')->default(1);
             $table->rememberToken();
             $table->timestamps();
         });

--- a/src/database/migrations/2022_09_25_174546_create_logins_table.php
+++ b/src/database/migrations/2022_09_25_174546_create_logins_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateLoginsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('logins', function (Blueprint $table) {
+            $table->integer('user_id')->unique();
+            $table->date('login_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('logins');
+    }
+}

--- a/src/database/seeders/LoginSeeder.php
+++ b/src/database/seeders/LoginSeeder.php
@@ -2,19 +2,18 @@
 
 namespace Database\Seeders;
 
+use App\Models\Login;
 use Illuminate\Database\Seeder;
 
-class DatabaseSeeder extends Seeder
+class LoginSeeder extends Seeder
 {
     /**
-     * Seed the application's database.
+     * Run the database seeds.
      *
      * @return void
      */
     public function run()
     {
-        $this->call([
-            LoginSeeder::class
-        ]);
+        Login::factory()->count(2)->create();
     }
 }

--- a/src/database/seeders/LoginSeeder.php
+++ b/src/database/seeders/LoginSeeder.php
@@ -14,6 +14,6 @@ class LoginSeeder extends Seeder
      */
     public function run()
     {
-        Login::factory()->count(2)->create();
+        Login::factory()->count(5)->create();
     }
 }

--- a/src/database/seeders/UserSeeder.php
+++ b/src/database/seeders/UserSeeder.php
@@ -3,9 +3,6 @@
 namespace Database\Seeders;
 
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Hash;
 
 class UserSeeder extends Seeder
 {
@@ -16,12 +13,6 @@ class UserSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('users')->insert([
-            'name'      => 'fugafuga',
-            'email'     => 'hoge@hoge.com',
-            'password'  => Hash::make('tt2123244'),
-            'comment'   => Str::random(10),
-            'total_continuation' => 27,
-        ]);
+        //
     }
 }

--- a/src/database/seeders/UserSeeder.php
+++ b/src/database/seeders/UserSeeder.php
@@ -18,7 +18,7 @@ class UserSeeder extends Seeder
     {
         DB::table('users')->insert([
             'name'      => 'fugafuga',
-            'email'     => Str::random(10) . '@gmail.com',
+            'email'     => 'hoge@hoge.com',
             'password'  => Hash::make('tt2123244'),
             'comment'   => Str::random(10),
             'total_continuation' => 27,

--- a/src/resources/sass/user/content.scss
+++ b/src/resources/sass/user/content.scss
@@ -90,11 +90,18 @@
             &__font {
                 font-size: 18px;
             }
-            .name, .comment, .continued {
-                margin-left: 100px;
+            .name, .comment, .continued, .cumulative {
+                text-align: center;
+
             }
-            .cumulative {
-                margin-left: 50px;
+            .name {
+                width: 35%;
+            }
+            .comment {
+                width: 25%;
+            }
+            .continued, .cumulative {
+                width: 15%;
             }
         }
     }

--- a/src/resources/views/layouts/header.blade.php
+++ b/src/resources/views/layouts/header.blade.php
@@ -22,8 +22,8 @@
             @auth
                 <a href="/" class="navlink">
                     <table style="height: 30px">
-                        <tr><td>継続/累計</td></tr>
-                        <tr><td>10/20</td></tr>
+                        <tr><td>継続/総計</td></tr>
+                        <tr><td>{{ $loginUser->total_continuation . '/' . $loginUser->total_cumulative }}</td></tr>
                     </table>
                     <img src="/image/fuji.png" alt="/" class="navlink--pic">
                     <i class="fa-solid fa-caret-down navlink--triangle"></i>

--- a/src/resources/views/report.blade.php
+++ b/src/resources/views/report.blade.php
@@ -15,15 +15,15 @@
                 <example-date></example-date>
             </div>
             <div class="area__list">
-                @for ($i = 0; $i < 5; $i++)
+                @foreach($userList as $user)
                     <div class="area__list__user">
                         <img src="/image/fuji.png" alt="/" class="pic">
-                        <p class="area__list__user__font name">hoge太郎</p>
-                        <p class="area__list__user__font comment">hogeレビュー</p>
-                        <p class="area__list__user__font continued">継続：10</p>
-                        <p class="area__list__user__font cumulative">累計：20</p>
+                        <p class="area__list__user__font name">{{ $user->name }}</p>
+                        <p class="area__list__user__font comment">{{ $user->comment}}</p>
+                        <p class="area__list__user__font continued">継続：{{ $user->total_continuation }}</p>
+                        <p class="area__list__user__font cumulative">総計：{{ $user->total_cumulative }}</p>
                     </div>
-                @endfor
+                @endforeach
             </div>
         </div>
     </div>


### PR DESCRIPTION
# Login Register

## 目的/期待値
- Login     ：条件によって加算 or default 1代入
- Register：default 1 代入
- Logins + users テーブルのファクトリ5件実行可能に修正

## 実装背景
- 継続数加算のたいタイミングをLogin 後にした方がクリック数軽減を図れる為

## 実装内容

### Login

- 継続

|ログインタイミング | 実行内容 |
|--|--|
| 昨日| `total_continuation` に+1加算する |
| 2日前以前 | `total_continuation` のデフォルト値 1 を代入する |

- 累計

| ログインタイミング | 実行内容 |
|--|--|
| 昨日以前 | `total_cumulative` に +1 加算する |

### Register

- 累計/継続

会員登録時に、 `total_continuation`  `total_cumulative` 共にデフォルト値 1 を加算する

## 参考文献 関連PRへの参照リンク
- [LaravelでFakerを使って、テストデータを作成する方法！](https://codelikes.com/laravel-faker/)
- laravel8 公式

## 確認事項 / 補足
- header 部分 累計/補足 部分がaタグで囲われてしまっている
- Login Register の発火処理を作成していない
